### PR TITLE
Add Endpoint mapping, fix minor annoyances

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -5,7 +5,7 @@ var hostnameEndpoints = {
 
 var endpoint = hostnameEndpoints[window.location.hostname];
 
-var newContentStr = '<body>' +
+var newContentStr = '<body style="display: block !important">' + //display reverses hide_at_start.css
 	'        <form action="' + endpoint + '" name="login" method="post">' +
 	'            <div>' +
 	'                <label for="un">Username:</label>' +
@@ -19,4 +19,4 @@ var newContentStr = '<body>' +
 	'        </form>' +
 	'    </body>';
 
-$('html body').replaceWith(newContentStr);
+$('html').html(newContentStr);

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,5 +1,12 @@
+var hostnameEndpoints = {
+  'test.salesforce.com' : 'https://test.salesforce.com/',
+  'login.salesforce.com' : 'https://login.salesforce.com/'
+};
+
+var endpoint = hostnameEndpoints[window.location.hostname];
+
 var newContentStr = '<body>' +
-	'        <form action="https://test.salesforce.com/" name="login" method="post">' +
+	'        <form action="' + endpoint + '" name="login" method="post">' +
 	'            <div>' +
 	'                <label for="un">Username:</label>' +
 	'                <input type="email" id="username" name="un"/>' +

--- a/hide_at_start.css
+++ b/hide_at_start.css
@@ -1,0 +1,4 @@
+/*This file hides body on doc load, to avoid flashing the Salesforce page before we replace it*/
+body {
+    display: none !important;
+};

--- a/manifest.json
+++ b/manifest.json
@@ -7,8 +7,7 @@
 		"tabs"
 	],
 	"content_scripts": [{
-		// "matches": ["https://test.salesforce.com/*", "https://login.salesforce.com/*"],
-		"matches": ["https://test.salesforce.com/*"],
+		"matches": ["https://test.salesforce.com/*", "https://login.salesforce.com/*"],
 		"js": ["jquery-2.1.1.min.js", "contentScript.js"],
 		"run_at": "document_end"
 	}]

--- a/manifest.json
+++ b/manifest.json
@@ -4,8 +4,7 @@
 	"version": "1.0",
 	"description": "Defaults to new identity",
 	"permissions": [
-		"tabs",
-		"https://code.jquery.com/jquery-2.1.1.min.js"
+		"tabs"
 	],
 	"content_scripts": [{
 		// "matches": ["https://test.salesforce.com/*", "https://login.salesforce.com/*"],

--- a/manifest.json
+++ b/manifest.json
@@ -6,9 +6,17 @@
 	"permissions": [
 		"tabs"
 	],
-	"content_scripts": [{
-		"matches": ["https://test.salesforce.com/*", "https://login.salesforce.com/*"],
-		"js": ["jquery-2.1.1.min.js", "contentScript.js"],
-		"run_at": "document_end"
-	}]
+	"content_scripts": [
+    {
+      //Hide the body at the start to avoid flashes of salesforce login page before we replace it
+      "matches": ["https://test.salesforce.com/*", "https://login.salesforce.com/*"],
+      "css": ["hide_at_start.css"],
+      "run_at": "document_start"
+    },
+    {
+  		"matches": ["https://test.salesforce.com/*", "https://login.salesforce.com/*"],
+  		"js": ["jquery-2.1.1.min.js", "contentScript.js"],
+  		"run_at": "document_end"
+  	}
+  ]
 }


### PR DESCRIPTION
- Adds endpoint mapping from window.location.hostname for test and login
- Prevents the brief flash of the default Salesforce page before we replace it
- replaceWith() for some reason didn't add the body. Fixed by doing $html.html() instead
